### PR TITLE
Feature: Namespace Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All Notable changes to `Midas` will be documented in this file
 
-## NEXT - 2015-03-05
+## v0.3 - 2015-03-05
 
 ### Added
 - Process Commands and Return Data

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -219,7 +219,7 @@ $two = $data->get(); // get's latest result
   * Ask a question
   * Chain questions
   * Use conjunctions
-  * Wrap questions in opperations
+  * Wrap questions in operations
  
 #### v0.5 Streaming A
   * Stream `$data` via an array of commands and algorightms

--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ $result = $midas->filter($data, $params); // etc
 ```
 This is all done with magic methods. There are some reserved words.
 
+#### Namespaced Commands
+You can also namespace your commands with dot notation. For instance, `one.two.three` and `a.b.four` are entirely different commands.
+This allows you to vendor prefix your commands just like composer packages. It is reccomended to use the same structure `vendor.package.command`.
+
+To issue or run a namespaced command, you have two options. First, you can use the `run()` method.
+```php
+$midas->addCommand('some.cool.example', function($data, $params) { return $data });
+$result = $midas->run('some.cool.example', $data, $params);
+```
+
+You may also use magic methods to get at it directly.
+```php
+$midas->addCommand('some.cool.example', function($data, $params) { return $data });
+$result = $midas->some->cool->example($data, $params);
+```
+
+Both of the above will work identically.
+
 ### Save and Manage Datasets
 You can also save sets of data to be reused. Anytime you have to manage something, the API is the similar as managing commands. In this case, only `fetch()` works differently.
 ```php

--- a/src/Midas.php
+++ b/src/Midas.php
@@ -315,14 +315,12 @@ class Midas
      */
     public function __call($name, $arguments)
     {
-        $command = $this->commands->fetch($name);
-        $data = isset($arguments[0]) ? $arguments[0] : null;
-        $params = (isset($arguments[1])) ? $arguments[1] : null;
-        $returnRefined = (isset($arguments[2])) ? $arguments[2] : true;
+        if ($name === "run") {
+            $command = array_shift($arguments);
+            return $this->issueCommand($command, $arguments);
+        }
 
-        $result = $command->run($data, $params);
-
-        return $this->ensureDataCollection($result, $returnRefined);
+        return $this->issueCommand($name, $arguments);
     }
 
     /**
@@ -339,5 +337,22 @@ class Midas
         } else {
             return $data;
         }
+    }
+
+    /**
+     * @param $name
+     * @param $arguments
+     * @return RefinedData
+     */
+    protected function issueCommand($name, $arguments)
+    {
+        $command = $this->commands->fetch($name);
+        $data = isset($arguments[0]) ? $arguments[0] : null;
+        $params = (isset($arguments[1])) ? $arguments[1] : null;
+        $returnRefined = (isset($arguments[2])) ? $arguments[2] : true;
+
+        $result = $command->run($data, $params);
+
+        return $this->ensureDataCollection($result, $returnRefined);
     }
 }

--- a/tests/Integration/MidasTest.php
+++ b/tests/Integration/MidasTest.php
@@ -3,6 +3,7 @@
 namespace Michaels\Midas\Test\Integration;
 
 use Codeception\Specify;
+use Michaels\Midas\Commands\CommandNotFoundException;
 use Michaels\Midas\Midas;
 use Michaels\Midas\Test\Stubs\ClassBasedCommand;
 
@@ -208,24 +209,42 @@ class MidasTest extends \PHPUnit_Framework_TestCase
             $actual = $midas->run('one.two.three');
             $this->assertTrue($actual, "failed to run namespaced command");
         });
-//
-//        $this->specify("it uses magic methods to issue namespaced commands", function() {
-//            $midas = new Midas();
-//
-//            $midas->addCommand('four.five.six', function($data, $params) {
-//                return $data . $params;
-//            });
-//
-//            $actual = $midas->four->five->six("data", "params");
-//            $this->assertEquals("dataparams", $actual, "failed to use magic methods to run command");
-//        });
+
+        $this->specify("it throws an exception from `run()` if no command", function() {
+            $midas = new Midas();
+
+            $midas->run('does.not.exist');
+        }, ['throws' => 'Michaels\Midas\Commands\CommandNotFoundException']);
+
+        $this->specify("it uses magic methods to issue namespaced commands", function() {
+            $midas = new Midas();
+
+            $midas->addCommand('four.five.six', function($data, $params) {
+                return $data[0] . $params[0];
+            });
+
+            $midas->addCommand('seven.eight.nine', function($data, $params) {
+                return $data[0] . $params[0];
+            });
+
+            $firstActual = $midas->four->five->six(["four-five-"], ["six"]);
+            $secondActual = $midas->seven->eight->nine(["seven-eight-"], ["nine"]);
+            $this->assertEquals("four-five-six", $firstActual, "failed to use magic methods to run command");
+            $this->assertEquals("seven-eight-nine", $secondActual, "failed to reset namespace and run seccond command");
+        });
+
+        $this->specify("it throws an exception from magic method if no command", function() {
+            $midas = new Midas();
+
+            $midas->does->not->exist();
+        }, ['throws' => 'Michaels\Midas\Commands\CommandNotFoundException']);
     }
 
     /**
      * @expectedException        InvalidArgumentException
      * @expectedExceptionMessage `data` is a reserved word
      */
-    public function testCommandExceptions()
+    public function testThrowsExceptionForReservedWord()
     {
         $midas = new Midas();
 

--- a/tests/Integration/MidasTest.php
+++ b/tests/Integration/MidasTest.php
@@ -173,6 +173,54 @@ class MidasTest extends \PHPUnit_Framework_TestCase
         });
     }
 
+    public function testNamespaceCommands()
+    {
+        // Namespaced Management is tested in tests/Unit/ManagerTest.php
+        $this->specify("it uses `run()` to issue commands without params", function() {
+            $midas = new Midas();
+
+            $midas->addCommand('noParams', function() {
+                return true;
+            });
+
+            $actual = $midas->run('noParams');
+            $this->assertTrue($actual, "failed to run testCommand with no args");
+        });
+
+        $this->specify("it uses `run()` to issue commands with params", function() {
+            $midas = new Midas();
+
+            $midas->addCommand('withParams', function($data, $params) {
+                return $data[0] . $params[0];
+            });
+
+            $actual = $midas->run('withParams', ["data"], ["params"]);
+            $this->assertEquals("dataparams", $actual, "failed to run command with params");
+        });
+
+        $this->specify("it uses `run()` to issue namespaced commands", function() {
+            $midas = new Midas();
+
+            $midas->addCommand('one.two.three', function() {
+                return true;
+            });
+
+            $actual = $midas->run('one.two.three');
+            $this->assertTrue($actual, "failed to run namespaced command");
+        });
+//
+//        $this->specify("it uses magic methods to issue namespaced commands", function() {
+//            $midas = new Midas();
+//
+//            $midas->addCommand('four.five.six', function($data, $params) {
+//                return $data . $params;
+//            });
+//
+//            $actual = $midas->four->five->six("data", "params");
+//            $this->assertEquals("dataparams", $actual, "failed to use magic methods to run command");
+//        });
+    }
+
     /**
      * @expectedException        InvalidArgumentException
      * @expectedExceptionMessage `data` is a reserved word


### PR DESCRIPTION
Adds the ability to namespace commands and issue them from `$midas->run()` or using magic methods `$midas->some->cool->example()`. See readme for more information. Tests included.